### PR TITLE
prevent News from overlapping with NewsFlashFilterPanel in Safari

### DIFF
--- a/src/components/molecules/NewsFlashFilterPanel.tsx
+++ b/src/components/molecules/NewsFlashFilterPanel.tsx
@@ -27,6 +27,7 @@ const useStyles = makeStyles({
     marginRight: '10px',
     display: 'flex',
     flexDirection: 'row',
+    flexShrink: 0,
     justifyContent: 'space-evenly',
   },
 });


### PR DESCRIPTION
add flex shrink 0 property to NewsFlashFilterPanel, resolves #250 