### PR TITLE
#296 - newsFlashWidgetsMetaString will return empty string if no location_info exists

### DIFF
--- a/src/store/root.store.ts
+++ b/src/store/root.store.ts
@@ -57,6 +57,7 @@ export default class RootStore {
 
   @computed
   get newsFlashWidgetsMetaString(): string {
+    if (!this.newsFlashWidgetsMeta.location_info) return '';
     let { resolution, road1, road_segment_name } = this.newsFlashWidgetsMeta.location_info;
     return `${resolution ? resolution : ''} ${road1 ? road1 : ''} ${road_segment_name ? road_segment_name : ''}`;
   }


### PR DESCRIPTION
on - src\store\root.store.ts
at newsFlashWidgetsMetaString():
added early return in case there is no location_info, in that case empty string will be returned.

#296 