### PR TITLE
fix inifinte scrolling timing and reformat with  prittier on component

### DIFF
--- a/src/components/atoms/InfinitScroll.tsx
+++ b/src/components/atoms/InfinitScroll.tsx
@@ -1,34 +1,35 @@
 import React, { FC, useEffect, useCallback, useRef } from 'react';
 import { makeStyles } from '@material-ui/core';
+import { useStore } from '../../store/storeConfig';
 
 function isScrollEnd(element: HTMLDivElement) {
-  return (element.scrollTop + element.clientHeight) === element.scrollHeight;
+  return element.scrollTop + element.clientHeight > element.scrollHeight - 30;
 }
 
 const useStyles = makeStyles({
   root: {
     overflow: 'auto',
     position: 'relative',
-  }
+  },
 });
 
 interface IProps {
   onScrollEnd: () => any;
 }
 
-const InfinitScroll: FC<IProps> = ({ children, onScrollEnd}) => {
+const InfinitScroll: FC<IProps> = ({ children, onScrollEnd }) => {
   const classes = useStyles();
   const scrollList = useRef<HTMLDivElement>(null);
-
+  const store = useStore();
 
   const handleScroll = useCallback(() => {
-    if (scrollList.current !== null) {
+    if (scrollList.current !== null && !store.newsFlashLoading) {
       if (isScrollEnd(scrollList.current)) {
         onScrollEnd();
       }
     }
   }, [scrollList, onScrollEnd]);
-  
+
   useEffect(() => {
     if (scrollList.current) {
       scrollList.current.addEventListener('scroll', handleScroll);
@@ -39,7 +40,7 @@ const InfinitScroll: FC<IProps> = ({ children, onScrollEnd}) => {
     <div ref={scrollList} className={classes.root}>
       {children}
     </div>
-  )
+  );
 };
 
 export default InfinitScroll;

--- a/src/components/atoms/InfinitScroll.tsx
+++ b/src/components/atoms/InfinitScroll.tsx
@@ -2,8 +2,10 @@ import React, { FC, useEffect, useCallback, useRef } from 'react';
 import { makeStyles } from '@material-ui/core';
 import { useStore } from '../../store/storeConfig';
 
+const INFINITE_SCROLLING_OFFSET: number = 30;
+
 function isScrollEnd(element: HTMLDivElement) {
-  return element.scrollTop + element.clientHeight > element.scrollHeight - 30;
+  return element.scrollTop + element.clientHeight > element.scrollHeight - INFINITE_SCROLLING_OFFSET;
 }
 
 const useStyles = makeStyles({

--- a/src/components/atoms/InfinitScroll.tsx
+++ b/src/components/atoms/InfinitScroll.tsx
@@ -28,7 +28,7 @@ const InfinitScroll: FC<IProps> = ({ children, onScrollEnd }) => {
         onScrollEnd();
       }
     }
-  }, [scrollList, onScrollEnd]);
+  }, [scrollList, onScrollEnd, store.newsFlashLoading]);
 
   useEffect(() => {
     if (scrollList.current) {


### PR DESCRIPTION
infinite scrolling fetch will be fired when the scroller will reach 30 px before the scroll end. also, I added a loading check on the scroll  event handler