### PR TITLE
fix- change ReactLeafletGoogleLayer map Type

### DIFF
--- a/src/components/molecules/map/GoogleMapsLayer.tsx
+++ b/src/components/molecules/map/GoogleMapsLayer.tsx
@@ -7,7 +7,7 @@ const GoogleMapsLayer: FC = ({ children }) => {
   return (
     <ReactLeafletGoogleLayer
       googleMapsLoaderConf={{ KEY: mapApiKey, VERSION: '3.40.6' }}
-      type="terrain"
+      type="roadmap"
       styles={MAP_STYLE}
     />
   );


### PR DESCRIPTION
fixed- changed     <ReactLeafletGoogleLayer> Type of map from 'terrain' to 'roadmap'
![image](https://user-images.githubusercontent.com/50585461/102349335-dcb8fb00-3fab-11eb-9fa0-e7870c0a0e28.png)

