### PR TITLE
Feat 616 add bold to typography

### DIFF
--- a/src/components/atoms/Typography.tsx
+++ b/src/components/atoms/Typography.tsx
@@ -1,49 +1,54 @@
 import React, { FC } from 'react';
 import Typo from '@material-ui/core/Typography';
 
-interface IText {
-  [property: string]: FC;
+interface IBold {
+  bold?: boolean;
 }
+interface IText {
+  [property: string]: FC<IBold>;
+}
+
+const style = { fontWeight: 'bold' } as const;
 
 // for styles of each variant - see 'theme.ts'
 const Typography: IText = {
-  Title1: ({ children }) => (
-    <Typo variant="subtitle1" component="h2">
+  Title1: ({ children }, bold) => (
+    <Typo style={bold && style} variant="subtitle1" component="h2">
       {children}
     </Typo>
   ),
-  Title2: ({ children }) => (
-    <Typo variant="subtitle2" component="h3">
+  Title2: ({ children }, bold) => (
+    <Typo style={bold && style} variant="subtitle2" component="h3">
       {children}
     </Typo>
   ),
-  Body1: ({ children }) => (
-    <Typo variant="h1" component="span">
+  Body1: ({ children }, bold) => (
+    <Typo style={bold && style} variant="h1" component="span">
       {children}
     </Typo>
   ),
-  Body2: ({ children }) => (
-    <Typo variant="h2" component="span">
+  Body2: ({ children }, bold) => (
+    <Typo style={bold && style} variant="h2" component="span">
       {children}
     </Typo>
   ),
-  Body3: ({ children }) => (
-    <Typo variant="h3" component="span">
+  Body3: ({ children }, bold) => (
+    <Typo style={bold && style} variant="h3" component="span">
       {children}
     </Typo>
   ),
-  Body4: ({ children }) => (
-    <Typo variant="h4" component="span">
+  Body4: ({ children }, bold) => (
+    <Typo style={bold && style} variant="h4" component="span">
       {children}
     </Typo>
   ),
-  Body5: ({ children }) => (
-    <Typo variant="h5" component="span">
+  Body5: ({ children }, bold) => (
+    <Typo style={bold && style} variant="h5" component="span">
       {children}
     </Typo>
   ),
-  Body6: ({ children }) => (
-    <Typo variant="h6" component="span">
+  Body6: ({ children }, bold) => (
+    <Typo style={bold && style} variant="h6" component="span">
       {children}
     </Typo>
   ),

--- a/src/components/atoms/Typography.tsx
+++ b/src/components/atoms/Typography.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 import Typo from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
 
 interface IBold {
   bold?: boolean;
@@ -8,47 +9,56 @@ interface IText {
   [property: string]: FC<IBold>;
 }
 
-const style = { fontWeight: 'bold' } as const;
+const useStyles = makeStyles(() => ({
+  bold: {
+    fontWeight: 'bold',
+  },
+}));
+
+const useBold = (bold: boolean) => {
+  const classes = useStyles();
+  return bold ? classes.bold : '';
+};
 
 // for styles of each variant - see 'theme.ts'
 const Typography: IText = {
   Title1: ({ children }, bold) => (
-    <Typo style={bold && style} variant="subtitle1" component="h2">
+    <Typo className={useBold(bold)} variant="subtitle1" component="h2">
       {children}
     </Typo>
   ),
   Title2: ({ children }, bold) => (
-    <Typo style={bold && style} variant="subtitle2" component="h3">
+    <Typo className={useBold(bold)} variant="subtitle2" component="h3">
       {children}
     </Typo>
   ),
   Body1: ({ children }, bold) => (
-    <Typo style={bold && style} variant="h1" component="span">
+    <Typo className={useBold(bold)} variant="h1" component="span">
       {children}
     </Typo>
   ),
   Body2: ({ children }, bold) => (
-    <Typo style={bold && style} variant="h2" component="span">
+    <Typo className={useBold(bold)} variant="h2" component="span">
       {children}
     </Typo>
   ),
   Body3: ({ children }, bold) => (
-    <Typo style={bold && style} variant="h3" component="span">
+    <Typo className={useBold(bold)} variant="h3" component="span">
       {children}
     </Typo>
   ),
   Body4: ({ children }, bold) => (
-    <Typo style={bold && style} variant="h4" component="span">
+    <Typo className={useBold(bold)} variant="h4" component="span">
       {children}
     </Typo>
   ),
   Body5: ({ children }, bold) => (
-    <Typo style={bold && style} variant="h5" component="span">
+    <Typo className={useBold(bold)} variant="h5" component="span">
       {children}
     </Typo>
   ),
   Body6: ({ children }, bold) => (
-    <Typo style={bold && style} variant="h6" component="span">
+    <Typo className={useBold(bold)} variant="h6" component="span">
       {children}
     </Typo>
   ),

--- a/src/components/molecules/TextView/TextViewHeader.tsx
+++ b/src/components/molecules/TextView/TextViewHeader.tsx
@@ -18,7 +18,6 @@ interface AProps {
 
 const useStyles = makeStyles((theme) => ({
   numOfAcc: {
-    fontWeight: 'bold',
     position: 'relative',
     bottom: theme.spacing(2),
     color: roadIconColors.red,
@@ -33,7 +32,7 @@ const AccidentsOccurred: FC<AProps> = ({ accidentsCount, singleType }) => {
     <Box mr={1} key={1}>
       <Typography.Body1>{t('textView.occurred')}</Typography.Body1>
     </Box>,
-    <Typography.Title1>
+    <Typography.Title1 bold>
       <Box className={classes.numOfAcc}>{accidentsCount}</Box>
     </Typography.Title1>,
     <Box mr={1} key={3}>


### PR DESCRIPTION
Solved #616 
Added bold option to typography atom component.
Now, every time we want to bold out text, we will use typo like this:
```
<Typography.Title1 bold {...other props}>
    // Some other code...
</Typography>
```
and it will get:`font-weight: bold` to his style.

Note:
I used the next syntex `const style={fontWieght : 'bold' } as const;` from [this SOF ans ](https://stackoverflow.com/a/48087031/8996605)