### PR TITLE
[FEAT-695] Hide language toggler and user icon

### DIFF
--- a/src/components/molecules/Header.tsx
+++ b/src/components/molecules/Header.tsx
@@ -52,8 +52,15 @@ const Header: FC = () => {
     }
   }
 
-  return (
-    <AppBar>
+  if (FEATURE_FLAGS.login) {
+    return <AppBar>
+      <Logo src={AnywayImage} alt={'Anyway'} height={30} onClick={reloadHomePage} />
+      <Box className={classes.userSection}>
+        {authElement}
+      </Box>
+    </AppBar>
+  } else {
+    return <AppBar>
       <Logo src={AnywayImage} alt={'Anyway'} height={30} onClick={reloadHomePage} />
       <Box className={classes.userSection}>
         <LanguageMenu />
@@ -65,7 +72,7 @@ const Header: FC = () => {
         )}
       </Box>
     </AppBar>
-  );
+  };
 };
 
 export default observer(Header);


### PR DESCRIPTION
Hide user icon and language toggler in production:
<img width="229" alt="Screenshot 2021-08-02 at 23 54 25" src="https://user-images.githubusercontent.com/61654174/127922791-7a2c8b3f-f692-46e2-9f26-4a124c6678d0.png">


