### PR TITLE
[Feat-776] Block Relative Imports ESlint Rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,10 @@
       ],
       "prefer-const": [
         "error"
+      ],
+      "no-restricted-imports": ["error", {
+        "patterns": ["./*"]
+        }  
       ]
     }
   },


### PR DESCRIPTION
The rule is described in detail here: https://eslint.org/docs/rules/no-restricted-imports

It works but causes ts 2307 error when the "./" is removed for imports from within the src:

<img width="718" alt="Screen Shot 2021-12-01 at 18 44 07" src="https://user-images.githubusercontent.com/61654174/144276193-bc9ec06a-68ae-4daa-aaea-e8643239078b.png">

<img width="892" alt="Screen Shot 2021-12-01 at 18 44 44" src="https://user-images.githubusercontent.com/61654174/144276302-81ebf372-19be-4280-9a59-5097e8e8ffd3.png">

I wasn't able to find how to resolve the ts error. 

 