### PR TITLE
[774] Adapt to new news-flash API

### DIFF
--- a/src/services/news.data.service.ts
+++ b/src/services/news.data.service.ts
@@ -30,8 +30,7 @@ export function fetchNews(source = '', offSet = 0, limit = 100): Promise<any> {
   }
   query.push(`offset=${offSet}`);
 
-  // temporary according to request from Atalya
-  query.push('road_segment_only=true&interurban_only=true');
+  query.push('resolution=suburban_road');
 
   const url = `${NEWS_FLASH_API}?${query.join('&')}`;
 


### PR DESCRIPTION
interurban_only and road_segment query parameters are deprecated.
a new query param is introduced: resolution.
currently requesting only suburban_road resolution (same as interurban).
later commits should add street resolution (per BE readiness).