### PR TITLE
[Fix-710] Fix "most_severe_accidents_table" overflows english - change headlines

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -78,7 +78,7 @@
   },
   "labelPosition": "Label Position",
   "table": {
-    "labels": ["Date", "Hour", "Type", "Killed", "Severe injured", "Light injured"]
+    "labels": ["Date", "Hour", "Type", "Killed", "Severe", "Light"]
   },
   "login": "LOGIN",
   "filterPanel": {


### PR DESCRIPTION
Changed headlines in English to fit in one line, same as in Hebrew