### PR TITLE
[Feat-901] Update accident_count_by_severity look

### DIFF
--- a/src/components/atoms/Typography.tsx
+++ b/src/components/atoms/Typography.tsx
@@ -44,6 +44,7 @@ const Typography: IText = {
   Body4: (props) => <TypographyBase variant="h4" component="span" {...props} />,
   Body5: (props) => <TypographyBase variant="h5" component="span" {...props} />,
   Body6: (props) => <TypographyBase variant="h6" component="span" {...props} />,
+  TextBody1: (props) => <TypographyBase variant="body1" component="h1" {...props} />,
 };
 
 export default Typography;

--- a/src/components/molecules/GenericBarChart.tsx
+++ b/src/components/molecules/GenericBarChart.tsx
@@ -101,6 +101,7 @@ const MultiBarChart: FC<IMultiBarChartProps> = ({ data, isPercentage, isStacked,
 
         return (
           <Bar
+            key={i}
             stackId={isStacked ? 'stack_1' : undefined}
             fill={colors[i]}
             dataKey={yLabels[i]}

--- a/src/components/molecules/PieChartView.tsx
+++ b/src/components/molecules/PieChartView.tsx
@@ -159,7 +159,7 @@ export const PieChartView: FC<IProps> = ({
       <PieChart>
         <defs>
           <filter id={PIE_SHADOW_ID}>
-            <feDropShadow dx="-3" dy="1" stdDeviation="2.5" flood-opacity="0.5" />
+            <feDropShadow dx="-3" dy="1" stdDeviation="2.5" floodOpacity="0.5" />
           </filter>
         </defs>
         <Pie

--- a/src/components/molecules/TextView/SeverityImage.tsx
+++ b/src/components/molecules/TextView/SeverityImage.tsx
@@ -4,7 +4,6 @@ import Ambulance from 'assets/Ambulance.png';
 import Crutches from 'assets/Crutches.png';
 import Box from '@material-ui/core/Box';
 import { makeStyles } from '@material-ui/core/styles';
-import classNames from 'classnames';
 
 interface SProps {
   severity: string;
@@ -12,9 +11,7 @@ interface SProps {
 }
 
 const useStyles = makeStyles((theme) => ({
-  root: {
-    width: '50%',
-  },
+
   singleType: {
     height: '40%',
     width: 'auto',
@@ -37,7 +34,7 @@ const SeverityImage: FC<SProps> = ({ severity, inRecord }) => {
     [index: string]: string;
   }
   const imgBySeverity: SeverityTypesImages = { fatal: Person, severe: Ambulance, light: Crutches };
-  const root = classNames(classes.root, inRecord ? classes.list : classes.singleType);
+  const root =  inRecord ? classes.list : classes.singleType;
   return (
     <Box className={root}>
       <img className={classes.image} src={imgBySeverity[severity]} alt={imgBySeverity[severity]} />

--- a/src/components/molecules/TextView/TextView.tsx
+++ b/src/components/molecules/TextView/TextView.tsx
@@ -31,7 +31,7 @@ interface IProps {
   severityFieldNames: ISeverityFieldNames;
   segmentText: string;
   labels: ITextViewLabels;
-  large_numbers: boolean;
+  largeNumbers: boolean;
 }
 
 export type IFormattedWidgetCountBySeverity = IWidgetCountBySeverityTextDataBase<ICountBySeverity>;
@@ -89,7 +89,7 @@ const TextView: FC<IProps> = ({
   segmentText,
   severityFieldNames: { fatal: fatalFieldName, severe: severeFieldName, light: lightFieldName, total: totalFieldName },
   labels,
-  large_numbers,
+  largeNumbers,
 }) => {
   const classes = useStyles();
 
@@ -120,7 +120,7 @@ const TextView: FC<IProps> = ({
         <SeverityImage severity={getSingleType(countBySeverity)!} />
       ) : (
         <Box color="text.secondary" className={classes.list}>
-          <TextViewList data={countBySeverity} labels={labels} large_numbers={large_numbers}/>
+          <TextViewList data={countBySeverity} labels={labels} largeNumbers={largeNumbers}/>
         </Box>
       )}
     </div>

--- a/src/components/molecules/TextView/TextView.tsx
+++ b/src/components/molecules/TextView/TextView.tsx
@@ -13,7 +13,7 @@ type ISeverityCounts<T> = {
   severe:T;
   light:T;
   total:T;
-} 
+}
 
 export type ICountBySeverity = ISeverityCounts<number>;
 export type ISeverityFieldNames = ISeverityCounts<string>;
@@ -49,8 +49,8 @@ const useStyles = makeStyles(() => ({
     alignItems: 'center',
   },
   headerBase: {
-    width: '70%',
-    height: '20%',
+    width: '80%',
+    height: '25%',
   },
   list: {
     width: '80%',

--- a/src/components/molecules/TextView/TextView.tsx
+++ b/src/components/molecules/TextView/TextView.tsx
@@ -31,6 +31,7 @@ interface IProps {
   severityFieldNames: ISeverityFieldNames;
   segmentText: string;
   labels: ITextViewLabels;
+  large_numbers: boolean;
 }
 
 export type IFormattedWidgetCountBySeverity = IWidgetCountBySeverityTextDataBase<ICountBySeverity>;
@@ -88,6 +89,7 @@ const TextView: FC<IProps> = ({
   segmentText,
   severityFieldNames: { fatal: fatalFieldName, severe: severeFieldName, light: lightFieldName, total: totalFieldName },
   labels,
+  large_numbers,
 }) => {
   const classes = useStyles();
 
@@ -118,7 +120,7 @@ const TextView: FC<IProps> = ({
         <SeverityImage severity={getSingleType(countBySeverity)!} />
       ) : (
         <Box color="text.secondary" className={classes.list}>
-          <TextViewList data={countBySeverity} labels={labels} />
+          <TextViewList data={countBySeverity} labels={labels} large_numbers={large_numbers}/>
         </Box>
       )}
     </div>

--- a/src/components/molecules/TextView/TextViewList.tsx
+++ b/src/components/molecules/TextView/TextViewList.tsx
@@ -1,33 +1,36 @@
 import React from 'react';
 import TextViewRecord from './TextViewRecord';
+import TextViewRecordLargeNumbers from './TextViewRecordLargeNumbers';
 import { useTranslation } from 'react-i18next';
 import { ICountBySeverity, ITextViewLabels } from './TextView';
 
 interface IProps {
   data: ICountBySeverity;
-  labels: ITextViewLabels
+  labels: ITextViewLabels;
+  large_numbers: boolean;
 }
 
-const TextViewList: React.FC<IProps> = ({ data, labels }) => {
+const TextViewList: React.FC<IProps> = ({ data, labels , large_numbers}) => {
   const { t } = useTranslation();
+  const ViewRecord = large_numbers ? TextViewRecordLargeNumbers : TextViewRecord;
   return (
     <>
       {data.fatal > 0 && (
-        <TextViewRecord
+        <ViewRecord
           numOfAccidents={data.fatal}
           severityDesc={t(`textView.${labels.fatal}.${data.fatal > 1 ? 'plural' : 'singular'}`)}
           imgSrc={'fatal'}
         />
       )}
       {data.severe > 0 && (
-        <TextViewRecord
+        <ViewRecord
           numOfAccidents={data.severe}
           severityDesc={t(`textView.${labels.severe}.${data.severe > 1 ? 'plural' : 'singular'}`)}
           imgSrc={'severe'}
         />
       )}
       {data.light > 0 && (
-        <TextViewRecord
+        <ViewRecord
           isLast={true}
           numOfAccidents={data.light}
           severityDesc={t(`textView.${labels.light}.${data.light > 1 ? 'plural' : 'singular'}`)}

--- a/src/components/molecules/TextView/TextViewList.tsx
+++ b/src/components/molecules/TextView/TextViewList.tsx
@@ -7,12 +7,12 @@ import { ICountBySeverity, ITextViewLabels } from './TextView';
 interface IProps {
   data: ICountBySeverity;
   labels: ITextViewLabels;
-  large_numbers: boolean;
+  largeNumbers: boolean;
 }
 
-const TextViewList: React.FC<IProps> = ({ data, labels , large_numbers}) => {
+const TextViewList: React.FC<IProps> = ({ data, labels , largeNumbers}) => {
   const { t } = useTranslation();
-  const ViewRecord = large_numbers ? TextViewRecordLargeNumbers : TextViewRecord;
+  const ViewRecord = largeNumbers ? TextViewRecordLargeNumbers : TextViewRecord;
   return (
     <>
       {data.fatal > 0 && (

--- a/src/components/molecules/TextView/TextViewList.tsx
+++ b/src/components/molecules/TextView/TextViewList.tsx
@@ -31,7 +31,6 @@ const TextViewList: React.FC<IProps> = ({ data, labels , largeNumbers}) => {
       )}
       {data.light > 0 && (
         <ViewRecord
-          isLast={true}
           numOfAccidents={data.light}
           severityDesc={t(`textView.${labels.light}.${data.light > 1 ? 'plural' : 'singular'}`)}
           imgSrc={'light'}

--- a/src/components/molecules/TextView/TextViewRecord.tsx
+++ b/src/components/molecules/TextView/TextViewRecord.tsx
@@ -27,6 +27,7 @@ const useStyles = makeStyles((theme) => ({
     alignItems: 'center',
     lineHeight: 0.5,
     justifyContent: 'center',
+    width: '50%',
   },
   acNum: {
     color: roadIconColors.red,

--- a/src/components/molecules/TextView/TextViewRecord.tsx
+++ b/src/components/molecules/TextView/TextViewRecord.tsx
@@ -18,6 +18,7 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: 'space-around',
     width: '80%',
     height: '20%',
+    py: 1,
   },
   text: {
     position: 'relative',
@@ -39,7 +40,7 @@ const useStyles = makeStyles((theme) => ({
 const TextViewRecord: React.FC<IProps> = ({ isLast, numOfAccidents, severityDesc, imgSrc }) => {
   const classes = useStyles();
   return (
-    <Box className={classes.root} py={1} borderBottom={isLast ? '' : `5px solid ${silverSmokeColor}`}>
+    <Box className={classes.root} borderBottom={isLast ? '' : `5px solid ${silverSmokeColor}`}>
       <SeverityImage inRecord severity={imgSrc} />
       <Box className={classes.text}>
         <Box className={classes.acNum}>{numOfAccidents}</Box>

--- a/src/components/molecules/TextView/TextViewRecord.tsx
+++ b/src/components/molecules/TextView/TextViewRecord.tsx
@@ -9,7 +9,6 @@ interface IProps {
   numOfAccidents: number;
   severityDesc: string;
   imgSrc: string;
-  isLast?: boolean;
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -19,6 +18,11 @@ const useStyles = makeStyles((theme) => ({
     width: '80%',
     height: '20%',
     py: 1,
+    borderBottom: '5px solid',
+    borderBlockColor: silverSmokeColor,
+    '&:last-child': {
+      borderBottom: '0px',
+    },
   },
   text: {
     position: 'relative',
@@ -37,10 +41,10 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const TextViewRecord: React.FC<IProps> = ({ isLast, numOfAccidents, severityDesc, imgSrc }) => {
+const TextViewRecord: React.FC<IProps> = ({numOfAccidents, severityDesc, imgSrc }) => {
   const classes = useStyles();
   return (
-    <Box className={classes.root} borderBottom={isLast ? '' : `5px solid ${silverSmokeColor}`}>
+    <Box className={classes.root}>
       <SeverityImage inRecord severity={imgSrc} />
       <Box className={classes.text}>
         <Box className={classes.acNum}>{numOfAccidents}</Box>

--- a/src/components/molecules/TextView/TextViewRecordLargeNumbers.tsx
+++ b/src/components/molecules/TextView/TextViewRecordLargeNumbers.tsx
@@ -9,7 +9,6 @@ interface IProps {
   numOfAccidents: number;
   severityDesc: string;
   imgSrc: string;
-  isLast?: boolean;
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -19,6 +18,11 @@ const useStyles = makeStyles((theme) => ({
     width: '80%',
     height: '20%',
     py: 1,
+    borderBottom: '5px solid',
+    borderBlockColor: silverSmokeColor,
+    '&:last-child': {
+      borderBottom: '0px',
+    },
   },
   text: {
     top: theme.spacing(2),
@@ -39,10 +43,10 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const TextViewRecordLargeNumbers: React.FC<IProps> = ({ isLast, numOfAccidents, severityDesc, imgSrc }) => {
+const TextViewRecordLargeNumbers: React.FC<IProps> = ({ numOfAccidents, severityDesc, imgSrc }) => {
   const classes = useStyles();
   return (
-    <Box className={classes.root} borderBottom={isLast ? '' : `5px solid ${silverSmokeColor}`}>
+    <Box className={classes.root}>
       <SeverityImage inRecord severity={imgSrc} />
       <Box className={classes.acNum}>
         <Typography.TextBody1>{numOfAccidents}</Typography.TextBody1>

--- a/src/components/molecules/TextView/TextViewRecordLargeNumbers.tsx
+++ b/src/components/molecules/TextView/TextViewRecordLargeNumbers.tsx
@@ -15,23 +15,20 @@ interface IProps {
 const useStyles = makeStyles((theme) => ({
   root: {
     display: 'flex',
-    top: theme.spacing(2),
     justifyContent: 'space-around',
     width: '80%',
     height: '20%',
   },
   text: {
-    position: 'relative',
-    top: theme.spacing(0.2),
+    top: theme.spacing(2),
     display: 'flex',
     alignItems: 'center',
     textAlign: 'center',
     justifyContent: 'center',
-    width: 110,
+    width: '30%',
   },
   acNum: {
     position: 'relative',
-    top: theme.spacing(0.2),
     display: 'flex',
     alignItems: 'center',
     textAlign: 'center',
@@ -39,11 +36,11 @@ const useStyles = makeStyles((theme) => ({
     color: roadIconColors.red,
     fontWeight: 'bold',
     fontSize: '350%',
-    width: 110,
+    width: '30%',
   },
 }));
 
-const TextViewRecord: React.FC<IProps> = ({ isLast, numOfAccidents, severityDesc, imgSrc }) => {
+const TextViewRecordLargeNumbers: React.FC<IProps> = ({ isLast, numOfAccidents, severityDesc, imgSrc }) => {
   const classes = useStyles();
   return (
     <Box className={classes.root} py={1} borderBottom={isLast ? '' : `5px solid ${silverSmokeColor}`}>
@@ -56,4 +53,4 @@ const TextViewRecord: React.FC<IProps> = ({ isLast, numOfAccidents, severityDesc
   );
 };
 
-export default TextViewRecord;
+export default TextViewRecordLargeNumbers;

--- a/src/components/molecules/TextView/TextViewRecordLargeNumbers.tsx
+++ b/src/components/molecules/TextView/TextViewRecordLargeNumbers.tsx
@@ -4,6 +4,7 @@ import { roadIconColors, silverSmokeColor } from 'style';
 import SeverityImage from './SeverityImage';
 import { makeStyles } from '@material-ui/core/styles';
 import { Typography } from 'components/atoms';
+import classNames from 'classnames';
 
 interface IProps {
   numOfAccidents: number;
@@ -14,32 +15,31 @@ interface IProps {
 const useStyles = makeStyles((theme) => ({
   root: {
     display: 'flex',
-    justifyContent: 'space-around',
-    width: '80%',
+    width: '90%',
     height: '20%',
-    py: 1,
     borderBottom: '5px solid',
     borderBlockColor: silverSmokeColor,
     '&:last-child': {
       borderBottom: '0px',
     },
   },
+  padding : {
+    padding : '0 10px'
+  },
   text: {
-    top: theme.spacing(2),
-    display: 'flex',
-    alignItems: 'center',
+    display:'flex',
+    alignItems: 'end',
     textAlign: 'center',
-    justifyContent: 'center',
-    width: '30%',
   },
   acNum: {
     position: 'relative',
     display: 'flex',
-    alignItems: 'center',
-    textAlign: 'center',
+    paddingLeft : theme.spacing(1),
+    paddingRight : theme.spacing(1),
+    alignItems: 'end',
+    textAlign: 'end',
     justifyContent: 'center',
     color: roadIconColors.red,
-    width: '30%',
   },
 }));
 
@@ -47,11 +47,11 @@ const TextViewRecordLargeNumbers: React.FC<IProps> = ({ numOfAccidents, severity
   const classes = useStyles();
   return (
     <Box className={classes.root}>
-      <SeverityImage inRecord severity={imgSrc} />
-      <Box className={classes.acNum}>
+      <SeverityImage  inRecord severity={imgSrc} />
+      <Box className={classNames(classes.acNum)}>
         <Typography.TextBody1>{numOfAccidents}</Typography.TextBody1>
       </Box>
-      <Box className={classes.text}>
+      <Box className={classNames(classes.text,classes.padding)}>
         <Typography.Title1>{severityDesc}</Typography.Title1>
       </Box>
     </Box>

--- a/src/components/molecules/TextView/TextViewRecordLargeNumbers.tsx
+++ b/src/components/molecules/TextView/TextViewRecordLargeNumbers.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import Box from '@material-ui/core/Box';
+import { roadIconColors, silverSmokeColor } from 'style';
+import SeverityImage from './SeverityImage';
+import { makeStyles } from '@material-ui/core/styles';
+import { Typography } from 'components/atoms';
+
+interface IProps {
+  numOfAccidents: number;
+  severityDesc: string;
+  imgSrc: string;
+  isLast?: boolean;
+}
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+    top: theme.spacing(2),
+    justifyContent: 'space-around',
+    width: '80%',
+    height: '20%',
+  },
+  text: {
+    position: 'relative',
+    top: theme.spacing(0.2),
+    display: 'flex',
+    alignItems: 'center',
+    textAlign: 'center',
+    justifyContent: 'center',
+    width: 110,
+  },
+  acNum: {
+    position: 'relative',
+    top: theme.spacing(0.2),
+    display: 'flex',
+    alignItems: 'center',
+    textAlign: 'center',
+    justifyContent: 'center',
+    color: roadIconColors.red,
+    fontWeight: 'bold',
+    fontSize: '350%',
+    width: 110,
+  },
+}));
+
+const TextViewRecord: React.FC<IProps> = ({ isLast, numOfAccidents, severityDesc, imgSrc }) => {
+  const classes = useStyles();
+  return (
+    <Box className={classes.root} py={1} borderBottom={isLast ? '' : `5px solid ${silverSmokeColor}`}>
+      <SeverityImage inRecord severity={imgSrc} />
+      <Box className={classes.acNum}>{numOfAccidents}</Box>
+      <Box className={classes.text}>
+        <Typography.Title1>{severityDesc}</Typography.Title1>
+      </Box>
+    </Box>
+  );
+};
+
+export default TextViewRecord;

--- a/src/components/molecules/TextView/TextViewRecordLargeNumbers.tsx
+++ b/src/components/molecules/TextView/TextViewRecordLargeNumbers.tsx
@@ -34,8 +34,6 @@ const useStyles = makeStyles((theme) => ({
     textAlign: 'center',
     justifyContent: 'center',
     color: roadIconColors.red,
-    fontWeight: 'bold',
-    fontSize: '350%',
     width: '30%',
   },
 }));
@@ -45,7 +43,9 @@ const TextViewRecordLargeNumbers: React.FC<IProps> = ({ isLast, numOfAccidents, 
   return (
     <Box className={classes.root} py={1} borderBottom={isLast ? '' : `5px solid ${silverSmokeColor}`}>
       <SeverityImage inRecord severity={imgSrc} />
-      <Box className={classes.acNum}>{numOfAccidents}</Box>
+      <Box className={classes.acNum}>
+        <Typography.TextBody1>{numOfAccidents}</Typography.TextBody1>
+      </Box>
       <Box className={classes.text}>
         <Typography.Title1>{severityDesc}</Typography.Title1>
       </Box>

--- a/src/components/molecules/TextView/TextViewRecordLargeNumbers.tsx
+++ b/src/components/molecules/TextView/TextViewRecordLargeNumbers.tsx
@@ -18,6 +18,7 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: 'space-around',
     width: '80%',
     height: '20%',
+    py: 1,
   },
   text: {
     top: theme.spacing(2),
@@ -41,7 +42,7 @@ const useStyles = makeStyles((theme) => ({
 const TextViewRecordLargeNumbers: React.FC<IProps> = ({ isLast, numOfAccidents, severityDesc, imgSrc }) => {
   const classes = useStyles();
   return (
-    <Box className={classes.root} py={1} borderBottom={isLast ? '' : `5px solid ${silverSmokeColor}`}>
+    <Box className={classes.root} borderBottom={isLast ? '' : `5px solid ${silverSmokeColor}`}>
       <SeverityImage inRecord severity={imgSrc} />
       <Box className={classes.acNum}>
         <Typography.TextBody1>{numOfAccidents}</Typography.TextBody1>

--- a/src/components/molecules/widgets/CountBySeverityTextWidget.tsx
+++ b/src/components/molecules/widgets/CountBySeverityTextWidget.tsx
@@ -7,11 +7,11 @@ interface IProps {
   segmentText: string;
   severityFieldNames: ISeverityFieldNames;
   labels: ITextViewLabels;
-  large_numbers?: boolean;
+  largeNumbers?: boolean;
 }
 const CountBySeverityTextWidget: FC<IProps> = ({ data, segmentText, severityFieldNames,
-                                                 labels, large_numbers= false}) => {
+                                                 labels, largeNumbers= false}) => {
   return <TextView data={data} segmentText={segmentText} severityFieldNames={severityFieldNames}
-                   labels={labels} large_numbers={large_numbers} />;
+                   labels={labels} largeNumbers={largeNumbers} />;
 };
 export default CountBySeverityTextWidget;

--- a/src/components/molecules/widgets/CountBySeverityTextWidget.tsx
+++ b/src/components/molecules/widgets/CountBySeverityTextWidget.tsx
@@ -7,9 +7,11 @@ interface IProps {
   segmentText: string;
   severityFieldNames: ISeverityFieldNames;
   labels: ITextViewLabels;
-  
+  large_numbers?: boolean;
 }
-const CountBySeverityTextWidget: FC<IProps> = ({ data, segmentText, severityFieldNames, labels }) => {
-  return <TextView data={data} segmentText={segmentText} severityFieldNames={severityFieldNames} labels={labels} />;
+const CountBySeverityTextWidget: FC<IProps> = ({ data, segmentText, severityFieldNames,
+                                                 labels, large_numbers= false}) => {
+  return <TextView data={data} segmentText={segmentText} severityFieldNames={severityFieldNames}
+                   labels={labels} large_numbers={large_numbers} />;
 };
 export default CountBySeverityTextWidget;

--- a/src/components/molecules/widgets/WidgetWrapper.tsx
+++ b/src/components/molecules/widgets/WidgetWrapper.tsx
@@ -93,7 +93,7 @@ const WidgetWrapper: FC<IProps> = ({ widget, locationText, sizeOptions, segmentT
             noun: 'accidents',
             verb: 'occurred',
           }}
-          large_numbers={true}
+          largeNumbers={true}
         />
       );
       break;

--- a/src/components/molecules/widgets/WidgetWrapper.tsx
+++ b/src/components/molecules/widgets/WidgetWrapper.tsx
@@ -93,6 +93,7 @@ const WidgetWrapper: FC<IProps> = ({ widget, locationText, sizeOptions, segmentT
             noun: 'accidents',
             verb: 'occurred',
           }}
+          large_numbers={true}
         />
       );
       break;

--- a/src/components/molecules/widgets/WidgetWrapper.tsx
+++ b/src/components/molecules/widgets/WidgetWrapper.tsx
@@ -93,7 +93,6 @@ const WidgetWrapper: FC<IProps> = ({ widget, locationText, sizeOptions, segmentT
             noun: 'accidents',
             verb: 'occurred',
           }}
-          largeNumbers={true}
         />
       );
       break;
@@ -116,6 +115,7 @@ const WidgetWrapper: FC<IProps> = ({ widget, locationText, sizeOptions, segmentT
             noun: 'injured',
             verb: 'hurt',
           }}
+          largeNumbers={true}
         />
       );
       break;

--- a/src/services/widgets.style.service.ts
+++ b/src/services/widgets.style.service.ts
@@ -27,7 +27,7 @@ const widgetVariants: { [index: string]: CardVariant } = {
   [WidgetName.most_severe_accidents]: { header: HeaderVariant.Centered, footer: FooterVariant.Logo },
   [WidgetName.most_severe_accidents_table]: { header: HeaderVariant.Centered, footer: FooterVariant.Logo },
   [WidgetName.accident_count_by_severity]: { header: HeaderVariant.Logo, footer: FooterVariant.None },
-  [WidgetName.injured_count_by_severity]: { header: HeaderVariant.Logo, footer: FooterVariant.None },
+  [WidgetName.injured_count_by_severity]: { header: HeaderVariant.Logo, footer: FooterVariant.Logo },
   [WidgetName.accident_count_by_accident_type]: { header: HeaderVariant.Centered, footer: FooterVariant.Logo },
   [WidgetName.accident_count_by_accident_year]: { header: HeaderVariant.Logo, footer: FooterVariant.None },
   [WidgetName.injured_count_by_accident_year]: { header: HeaderVariant.Logo, footer: FooterVariant.None },

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -49,8 +49,10 @@ const defaultThemeOptions: ThemeOptions = {
       fontSize: 13,
     },
     body1: {
-      fontSize: '350%',
+      fontSize: 56,
       fontWeight: "bold",
+      lineHeight:1
+
     },
   },
 };

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -48,6 +48,10 @@ const defaultThemeOptions: ThemeOptions = {
     h6: {
       fontSize: 13,
     },
+    body1: {
+      fontSize: '350%',
+      fontWeight: "bold",
+    },
   },
 };
 


### PR DESCRIPTION
Issue https://github.com/hasadna/anyway-newsflash-infographics/issues/901
Made accident_count_by_severity look different from injured_count_by_severity, by changing numbers' size
Made some changes also in injured_count_by_severity to make centering better